### PR TITLE
OSS-Fuzz: Add new fuzzer targets read process

### DIFF
--- a/ossfuzz/Makefile.am
+++ b/ossfuzz/Makefile.am
@@ -12,7 +12,8 @@ AM_CPPFLAGS = \
 	@LIBBFIO_CPPFLAGS@
 
 bin_PROGRAMS = \
-	file_fuzzer
+	file_fuzzer \
+	read_fuzzer
 
 file_fuzzer_SOURCES = \
 	file_fuzzer.cc \
@@ -20,6 +21,24 @@ file_fuzzer_SOURCES = \
 	ossfuzz_libvhdi.h
 
 file_fuzzer_LDADD = \
+	@LIB_FUZZING_ENGINE@ \
+	@LIBBFIO_LIBADD@ \
+	@LIBCPATH_LIBADD@ \
+	@LIBCFILE_LIBADD@ \
+	@LIBUNA_LIBADD@ \
+	@LIBCDATA_LIBADD@ \
+	../libvhdi/libvhdi.la \
+	@LIBCNOTIFY_LIBADD@ \
+	@LIBCLOCALE_LIBADD@ \
+	@LIBCERROR_LIBADD@ \
+	@LIBINTL@
+
+read_fuzzer_SOURCES = \
+	read_fuzzer.cc \
+	ossfuzz_libbfio.h \
+	ossfuzz_libvhdi.h
+
+read_fuzzer_LDADD = \
 	@LIB_FUZZING_ENGINE@ \
 	@LIBBFIO_LIBADD@ \
 	@LIBCPATH_LIBADD@ \

--- a/ossfuzz/read_fuzzer.cc
+++ b/ossfuzz/read_fuzzer.cc
@@ -1,0 +1,125 @@
+/*
+ * OSS-Fuzz target for libvhdi read buffer
+ *
+ * Copyright (C) 2012-2026, Joachim Metz <joachim.metz@gmail.com>
+ *
+ * Refer to AUTHORS for acknowledgements.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Note that some of the OSS-Fuzz engines use C++
+ */
+extern "C" {
+
+#include "ossfuzz_libbfio.h"
+#include "ossfuzz_libvhdi.h"
+
+#if !defined( LIBVHDI_HAVE_BFIO )
+
+/* Opens a file using a Basic File IO (bfio) handle
+ * Returns 1 if successful or -1 on error
+ */
+LIBVHDI_EXTERN \
+int libvhdi_file_open_file_io_handle(
+     libvhdi_file_t *file,
+     libbfio_handle_t *file_io_handle,
+     int access_flags,
+     libvhdi_error_t **error );
+
+#endif /* !defined( LIBVHDI_HAVE_BFIO ) */
+
+int LLVMFuzzerTestOneInput(
+     const uint8_t *data,
+     size_t size )
+{
+	uint8_t buffer[ 4096 ];
+	libbfio_handle_t *file_io_handle = NULL;
+	libvhdi_file_t *file             = NULL;
+	size64_t media_size              = 0;
+	off64_t offset                   = 0;
+	int iterations                   = 0;
+
+	if( libbfio_memory_range_initialize(
+	     &file_io_handle,
+	     NULL ) != 1 )
+	{
+		return( 0 );
+	}
+	if( libbfio_memory_range_set(
+	     file_io_handle,
+	     (uint8_t *) data,
+	     size,
+	     NULL ) != 1 )
+	{
+		goto on_error_libbfio;
+	}
+	if( libvhdi_file_initialize(
+	     &file,
+	     NULL ) != 1 )
+	{
+		goto on_error_libbfio;
+	}
+	if( libvhdi_file_open_file_io_handle(
+	     file,
+	     file_io_handle,
+	     LIBVHDI_OPEN_READ,
+	     NULL ) != 1 )
+	{
+		goto on_error_libvhdi;
+	}
+	if( libvhdi_file_get_media_size(
+	     file,
+	     &media_size,
+	     NULL ) == 1 )
+	{
+		while( ( offset < (off64_t) media_size )
+		    && ( iterations < 2048 ) )
+		{
+			ssize_t read_count = libvhdi_file_read_buffer_at_offset(
+			                      file,
+			                      buffer,
+			                      sizeof( buffer ),
+			                      offset,
+			                      NULL );
+
+			if( read_count <= 0 )
+			{
+				break;
+			}
+			offset += read_count;
+			iterations++;
+		}
+	}
+	libvhdi_file_close(
+	 file,
+	 NULL );
+
+on_error_libvhdi:
+	libvhdi_file_free(
+	 &file,
+	 NULL );
+
+on_error_libbfio:
+	libbfio_handle_free(
+	 &file_io_handle,
+	 NULL );
+
+	return( 0 );
+}
+
+} /* extern "C" */


### PR DESCRIPTION
This PR adds a new OSS-Fuzz fuzzer targets the read process of the libvhdi, bundled in the libyal project from OSS-Fuzz.